### PR TITLE
Fix column 'More' options overlapping when 3-4 columns

### DIFF
--- a/assets/scss/mesh/_structure.scss
+++ b/assets/scss/mesh/_structure.scss
@@ -408,8 +408,52 @@
 			    &:nth-of-type(4) {
 				    padding-left: 26px;
 			    }
-		    }
+
+				.mesh-block-meta-dropdown{
+					.left {
+						width: 100%;
+						margin-bottom: 1em;
+
+						label {
+							display: block;
+
+							input {
+								display: block;
+								max-width: 100%;
+							}
+						}
+					}
+
+					.right {
+						width: 100%;
+					}
+				}
+			}
 	    }
+
+		&[data-mesh-blocks="4"] {
+			~ .mesh-section-block {
+				.mesh-block-meta-dropdown{
+					.left {
+						width: 100%;
+						margin-bottom: 1em;
+
+						label {
+							display: block;
+
+							input {
+								display: block;
+								max-width: 100%;
+							}
+						}
+					}
+
+					.right {
+						width: 100%;
+					}
+				}
+			}
+		}
 	}
 
 	> .mesh-row {


### PR DESCRIPTION
#18 

There are probably a few ways to fix this issue, but my solution is to stack the left and right divs when there are 3-4 columns. I also made the "CSS Class" label and input box "display:block" so they would be on their own lines. This keeps everything from overlapping and overflowing.

When you compile the Sass, this is what it looks like:

![fix-18](https://cloud.githubusercontent.com/assets/8797898/17460193/fa2a26f2-5c28-11e6-954e-0226e2aca9d2.jpg)
