### PR TITLE
Fix column selection saving via AJAX

### DIFF
--- a/class.mesh-ajax.php
+++ b/class.mesh-ajax.php
@@ -124,8 +124,6 @@ class Mesh_AJAX {
 			wp_die();
 		}
 
-		update_post_meta( $section_id, '_mesh_template', $selected_template );
-
 		$block_template = mesh_locate_template_files();
 
 		$templates = apply_filters( 'mesh_section_data', $block_template );


### PR DESCRIPTION
#17 

Removed update_post_meta for _mesh_template in mesh_choose_layout function. This stops the column selection from saving via AJAX. Tested to make sure, and also that it does still save when you use the Update button.