### PR TITLE
Fix weird text being echoed on settings page

### DIFF
--- a/class.mesh-settings.php
+++ b/class.mesh-settings.php
@@ -196,8 +196,6 @@ class Mesh_Settings {
 	 */
 	public static function add_select( $args ) {
 
-		echo 'this is something htat sadsad adsa';
-
 		/**
 		 * Define our field defaults
 		 */


### PR DESCRIPTION
There was some weird text being echoed on the settings page:

![settings-page-weird-text](https://cloud.githubusercontent.com/assets/8797898/17465543/09257b1c-5cc8-11e6-87a2-53dd8bf73840.JPG)