### PR TITLE
Load textcolor plugin in mesh tinymce

### DIFF
--- a/admin/section-blocks.php
+++ b/admin/section-blocks.php
@@ -137,7 +137,7 @@
 								'statusbar'             => true,
 								'autoresize_min_height' => 150,
 								'wp_autoresize_on'      => false,
-								'plugins'               => 'lists,media,paste,tabfocus,wordpress,wpautoresize,wpeditimage,wpgallery,wplink,wptextpattern,wpview',
+								'plugins'               => 'lists,media,paste,tabfocus,wordpress,textcolor,wpautoresize,wpeditimage,wpgallery,wplink,wptextpattern,wpview',
 								'toolbar1'              => 'bold,italic,bullist,numlist,hr,alignleft,aligncenter,alignright,alignjustify,link,wp_adv',
 								'toolbar2'              => 'formatselect,underline,strikethrough,forecolor,pastetext,removeformat',
 							),


### PR DESCRIPTION
The option for color picking text was not available even though the tinymce filters with 'forecolor' in toolbar2. The text color plugin needs to be loaded in order for that toolbar button to become available.