### PR TITLE
Fix mesh_post_types PHP 5.4 compatibility

### DIFF
--- a/class.mesh-templates.php
+++ b/class.mesh-templates.php
@@ -112,7 +112,9 @@ class Mesh_Templates {
 			'rewrite' => false,
 		) );
 
-		$mesh_post_types = array_keys( get_option( 'mesh_post_types' ) );
+		// Using an extra variable for the array to support PHP 5.4
+		$mesh_post_types_array = get_option( 'mesh_post_types' );
+		$mesh_post_types = array_keys( $mesh_post_types_array );
 		$available_post_types = array_merge( array( 'mesh_template' ), $mesh_post_types );
 
 		register_taxonomy( 'mesh_template_usage', $available_post_types, array(


### PR DESCRIPTION
This fixes the issue from https://wordpress.org/support/topic/error-upon-activation-8/