### PR TITLE
Fix broken upgrade path

### DIFF
--- a/mesh.php
+++ b/mesh.php
@@ -34,7 +34,7 @@ define( 'LINCHPIN_MESH___PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
  */
 define( 'LINCHPIN_MESH_DEBUG_MODE', false );
 
-$GLOBALS['mesh_current_version'] = get_option( 'mesh_version', '0.0' ); // Get our current Mesh Version.
+$GLOBALS['mesh_current_version'] = get_option( 'mesh_version', LINCHPIN_MESH_VERSION ); // Get our current Mesh Version.
 
 include_once 'class.mesh-settings.php';
 include_once 'class.mesh-templates.php';


### PR DESCRIPTION
If plugin hasn't been installed before, the current mesh version should be set
to the LINCHPIN_MESH_VERSION constant. Otherwise, every update will be run on
initial activation which is completely unnecessary.